### PR TITLE
Release version 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## Unreleased
+## [2.9.0] - 2026-03-13
 
 - Add Sending Stats API
+- Parse `reply_to` as a structured address field instead of passing it as a raw
+  header when sending with Action Mailer
 
 ## [2.8.0] - 2026-03-03
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mailtrap (2.8.0)
+    mailtrap (2.9.0)
       base64
 
 GEM

--- a/lib/mailtrap/mail.rb
+++ b/lib/mailtrap/mail.rb
@@ -190,8 +190,7 @@ module Mailtrap
       # Builds a mail object from Mail::Message
       # @param message [Mail::Message]
       # @return [Mailtrap::Mail::Base]
-      # rubocop:disable Metrics/AbcSize
-      def from_message(message)
+      def from_message(message) # rubocop:disable Metrics/AbcSize
         Mailtrap::Mail::Base.new(
           from: prepare_addresses(message['from']).first,
           to: prepare_addresses(message['to']),
@@ -209,7 +208,6 @@ module Mailtrap
           template_variables: message['template_variables']&.unparsed_value
         )
       end
-      # rubocop:enable Metrics/AbcSize
 
       private
 

--- a/lib/mailtrap/version.rb
+++ b/lib/mailtrap/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mailtrap
-  VERSION = '2.8.0'
+  VERSION = '2.9.0'
 end

--- a/spec/mailtrap/mail_spec.rb
+++ b/spec/mailtrap/mail_spec.rb
@@ -199,31 +199,16 @@ RSpec.describe Mailtrap::Mail do
       its(:template_variables) { is_expected.to eq('first_name' => 'John') }
     end
 
-    %i[from to cc bcc].each do |header|
+    %w[from to cc bcc reply-to].each do |header|
       context "when '#{header}' is invalid" do
         let(:message_params) { super().merge(header => 'invalid email@example.com') }
 
         it 'raises an error' do
           expect { mail }.to raise_error(
             Mailtrap::Error,
-            "failed to parse '#{header.capitalize}': 'invalid email@example.com'"
+            "failed to parse '#{Mail::Field::FIELD_NAME_MAP[header]}': 'invalid email@example.com'"
           )
         end
-      end
-    end
-
-    context "when 'reply-to' is invalid" do
-      let(:invalid_reply_to) { 'invalid email@example.com' }
-
-      before do
-        message.header['Reply-To'] = invalid_reply_to
-      end
-
-      it 'raises an error' do
-        expect { mail }.to raise_error(
-          Mailtrap::Error,
-          "failed to parse 'Reply-To': 'invalid email@example.com'"
-        )
       end
     end
   end

--- a/spec/mailtrap/mail_spec.rb
+++ b/spec/mailtrap/mail_spec.rb
@@ -52,29 +52,6 @@ RSpec.describe Mailtrap::Mail do
 
         it { is_expected.to eq(expected_headers) }
       end
-
-      context 'when reply-to is added in varying formats' do
-        before do
-          message.reply_to = 'Reply To <reply-to@railsware.com>'
-        end
-
-        it 'excludes reply-to from custom headers' do
-          expect(headers).not_to have_key('Reply-To')
-        end
-      end
-
-      context 'when custom header and reply-to variants are present' do
-        before do
-          message.header['Reply-To'] = 'Reply To <reply-to@railsware.com>'
-          message.header['REPLY-TO'] = 'Upper Case <upper-reply-to@railsware.com>'
-          message.header['reply-to'] = 'Lower Case <lower-reply-to@railsware.com>'
-          message.header['X-Special-Domain-Specific-Header'] = 'SecretValue'
-        end
-
-        it 'keeps only custom headers and strips all reply-to header variants' do
-          expect(headers).to eq('X-Special-Domain-Specific-Header' => 'SecretValue')
-        end
-      end
     end
 
     describe '#reply_to' do
@@ -84,18 +61,6 @@ RSpec.describe Mailtrap::Mail do
 
       it 'maps reply-to to the structured field' do
         expect(mail.reply_to).to eq(email: 'reply-to@railsware.com', name: 'Reply To')
-      end
-
-      context 'when reply-to header variants are present' do
-        before do
-          message.header['Reply-To'] = 'Reply To <reply-to@railsware.com>'
-          message.header['REPLY-TO'] = 'Upper Case <upper-reply-to@railsware.com>'
-          message.header['reply-to'] = 'Lower Case <lower-reply-to@railsware.com>'
-        end
-
-        it 'maps the reply-to value to the structured field' do
-          expect(mail.reply_to).to eq({ email: 'lower-reply-to@railsware.com', name: 'Lower Case' })
-        end
       end
     end
 


### PR DESCRIPTION
## Motivation

Release version 2.9.0

## Changes

- Add Sending Stats API
- Parse `reply_to` as a structured address field instead of passing it as a raw
  header when sending with Action Mailer

## How to test

- [ ] Stats
- [ ] Reply-To field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `reply_to` field is now parsed as a structured address field when sending with Action Mailer, improving consistency with standard email field handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->