### PR TITLE
Implement draft-release workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -33,6 +33,11 @@ jobs:
           fetch-depth: 0
           ref: main
 
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
       - name: Read current version
         id: read
         run: |
@@ -69,6 +74,11 @@ jobs:
             VERSION = '${NEXT}'
           end
           EOF
+
+      - name: Install dependencies
+        if: steps.notes.outputs.release_notes != ''
+        run: |
+          bundle install
 
       - name: Prepend new section to CHANGELOG.md
         if: steps.notes.outputs.release_notes != ''

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,4 +1,5 @@
-# Placeholder draft-release workflow
+# Drafts new mailtrap-ruby release: bumps the version, regenerates the changelog from
+# merged PRs, and opens a release PR against main.
 #
 name: Draft ruby Release
 on:
@@ -14,14 +15,81 @@ on:
           - major
         default: patch
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   draft-release:
-    name: Draft ruby Release (placeholder)
+    name: Draft mailtrap-ruby Release
     runs-on: ubuntu-latest
     steps:
-      - name: Echo inputs
-        env:
-          BUMP_TYPE: ${{ inputs.bump_type }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Read current version
+        id: read
         run: |
-          echo "Placeholder draft-release workflow"
-          echo "bump_type=$BUMP_TYPE"
+          version=$(ruby -r "./lib/mailtrap/version.rb" -e "puts Mailtrap::VERSION")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Compute next version
+        id: bump
+        uses: railsware/github-actions/compute-next-semver@master
+        with:
+          current: ${{ steps.read.outputs.version }}
+          bump-type: ${{ inputs.bump_type }}
+
+      - name: Abort if tag already exists
+        uses: railsware/github-actions/abort-if-tag-exists@master
+        with:
+          tag: ${{ steps.bump.outputs.tag }}
+
+      - name: Generate release notes
+        id: notes
+        uses: railsware/github-actions/generate-release-notes@master
+        with:
+          tag: ${{ steps.bump.outputs.tag }}
+
+      - name: Update version in version file
+        if: steps.notes.outputs.release_notes != ''
+        env:
+          NEXT: ${{ steps.bump.outputs.next }}
+        run: |
+          cat > "./lib/mailtrap/version.rb" <<EOF
+          # frozen_string_literal: true
+
+          module Mailtrap
+            VERSION = '${NEXT}'
+          end
+          EOF
+
+      - name: Prepend new section to CHANGELOG.md
+        if: steps.notes.outputs.release_notes != ''
+        uses: railsware/github-actions/prepend-changelog@master
+        with:
+          version: ${{ steps.bump.outputs.next }}
+          release-notes: ${{ steps.notes.outputs.release_notes }}
+
+      - name: Commit, push, open PR
+        if: steps.notes.outputs.release_notes != ''
+        uses: railsware/github-actions/open-sdk-release-pr@master
+        with:
+          tag: ${{ steps.bump.outputs.tag }}
+          current: ${{ steps.read.outputs.version }}
+          next: ${{ steps.bump.outputs.next }}
+          bump-type: ${{ inputs.bump_type }}
+          release-notes: ${{ steps.notes.outputs.release_notes }}
+
+      - name: Create draft GitHub release
+        if: steps.notes.outputs.release_notes != ''
+        uses: railsware/github-actions/create-draft-github-release@master
+        with:
+          tag: ${{ steps.bump.outputs.tag }}
+          release-notes: ${{ steps.notes.outputs.release_notes }}


### PR DESCRIPTION
## Motivation

Automate releases

## Changes

- Implement draft release

## How to test

- [ ] Trigger draft-release workflow for this branch
- [ ] Assert that new release PR is created with changes similar to [manual release](https://github.com/mailtrap/mailtrap-ruby/pull/109)
- [ ] Assert draft Github release is created 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated draft release creation with version bump selection, release notes generation, changelog updates, and a draft GitHub release.
* **Chores**
  * Added safeguards to prevent duplicate release tags and to keep release runs from overlapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->