### PR TITLE
MT-22678: Add name search filter to contact lists listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Email Sandbox (Testing):
 
 Contact management:
 
-- Contacts CRUD & Listing – [`contacts_api.rb`](examples/contacts_api.rb)
+- Contacts CRUD & Listing – [`contacts_api.rb`](examples/contacts_api.rb) (contact lists support filtering by name via `list(search:)`)
 
 General:
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Email Sandbox (Testing):
 
 Contact management:
 
-- Contacts CRUD & Listing – [`contacts_api.rb`](examples/contacts_api.rb) (contact lists support filtering by name via `list(search:)`)
+- Contacts CRUD & Listing – [`contacts_api.rb`](examples/contacts_api.rb)
 
 General:
 

--- a/examples/contacts_api.rb
+++ b/examples/contacts_api.rb
@@ -24,6 +24,10 @@ list = contact_lists.create(name: 'Test List')
 contact_lists.list
 # => [#<struct Mailtrap::ContactList id=1, name="Test List">]
 
+# Filter contact lists by name (case-insensitive prefix match)
+contact_lists.list(search: 'news')
+# => [#<struct Mailtrap::ContactList id=2, name="Newsletter">]
+
 # Update contact list
 contact_lists.update(list.id, name: 'Test List Updated')
 # => #<struct Mailtrap::ContactList id=1, name="Test List Updated">

--- a/lib/mailtrap/contact_lists_api.rb
+++ b/lib/mailtrap/contact_lists_api.rb
@@ -49,10 +49,14 @@ module Mailtrap
     end
 
     # Lists all contact lists for the account
+    # @param search [String] Filters contact lists by name (case-insensitive prefix match)
     # @return [Array<ContactList>] Array of contact list objects
     # @!macro api_errors
-    def list
-      base_list
+    def list(search: nil)
+      query_params = {}
+      query_params[:search] = search unless search.nil?
+
+      base_list(query_params)
     end
 
     private

--- a/spec/mailtrap/contact_lists_api_spec.rb
+++ b/spec/mailtrap/contact_lists_api_spec.rb
@@ -25,6 +25,21 @@ RSpec.describe Mailtrap::ContactListsAPI do
       expect(response.length).to eq(2)
       expect(response.first).to have_attributes(id: 1, name: 'List 1')
     end
+
+    it 'filters contact lists by name' do
+      stub = stub_request(:get, "#{base_url}/contacts/lists")
+             .with(query: { search: 'news' })
+             .to_return(
+               status: 200,
+               body: [{ 'id' => 2, 'name' => 'Newsletter' }].to_json,
+               headers: { 'Content-Type' => 'application/json' }
+             )
+
+      response = client.list(search: 'news')
+      expect(stub).to have_been_requested
+      expect(response.length).to eq(1)
+      expect(response.first).to have_attributes(id: 2, name: 'Newsletter')
+    end
   end
 
   describe '#get' do


### PR DESCRIPTION
## Motivation

https://railsware.atlassian.net/browse/MT-22678

## Changes

- Add an optional `search` keyword to `ContactListsApi#list` — filters contact lists by name (case-insensitive prefix match), per the OpenAPI `GET /api/contacts/lists` param. When omitted the request is unchanged, so the call stays backward compatible.

## How to test

- [ ] `client.contact_lists.list` — returns all contact lists (unchanged behaviour).
- [ ] `client.contact_lists.list(search: "news")` — returns only lists whose name starts with "news" (case-insensitive).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for filtering contact lists by name using a case-insensitive prefix search.
  * Updated contact list examples to demonstrate the new search option.

* **Documentation**
  * Updated the supported functionality and examples documentation to include contact list filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->