### PR TITLE
Redact API token values from VCR cassettes

### DIFF
--- a/spec/fixtures/vcr_cassettes/Mailtrap_ApiTokensAPI/_create/maps_response_data_to_ApiToken_with_full_token_value.yml
+++ b/spec/fixtures/vcr_cassettes/Mailtrap_ApiTokensAPI/_create/maps_response_data_to_ApiToken_with_full_token_value.yml
@@ -69,6 +69,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"resources":[{"resource_type":"account","resource_id":1719941,"access_level":100}],"id":2498713,"name":"Ruby
-        SDK Test Token","last_4_digits":"dcf7","created_by":"SDK Dev Account Token","expires_at":null,"token":"d5335b07610bd99b7fbc03f80e26dcf7"}'
+        SDK Test Token","last_4_digits":"dcf7","created_by":"SDK Dev Account Token","expires_at":null,"token":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
   recorded_at: Wed, 29 Apr 2026 14:21:57 GMT
 recorded_with: VCR 6.4.0

--- a/spec/fixtures/vcr_cassettes/Mailtrap_ApiTokensAPI/_reset/maps_response_data_to_ApiToken_with_new_token_value.yml
+++ b/spec/fixtures/vcr_cassettes/Mailtrap_ApiTokensAPI/_reset/maps_response_data_to_ApiToken_with_new_token_value.yml
@@ -70,6 +70,6 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"resources":[{"resource_type":"account","resource_id":1719941,"access_level":100}],"id":2498715,"name":"Ruby
         SDK Test Token 2498715","last_4_digits":"856f","created_by":"SDK Dev Account
-        Token","expires_at":null,"token":"ff828c557cb54180a0ce279fd6d5856f"}'
+        Token","expires_at":null,"token":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
   recorded_at: Wed, 29 Apr 2026 14:25:08 GMT
 recorded_with: VCR 6.4.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,7 @@ VCR.configure do |config|
       '"forward_from_email_address": "railsware@forward.mailtrap.info"'
     )
     interaction.response.body.gsub!(/"email_username":"[^"]*"/, '"email_username": "1234abcd"')
+    interaction.response.body.gsub!(/"token":"[^"]*"/, '"token":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"')
 
     auth_header = interaction.request.headers['Authorization']&.first
 


### PR DESCRIPTION
## Motivation

The VCR config in `spec/spec_helper.rb` scrubs the `Authorization` request header and a
number of response body fields (`signing_secret`, `password`, `email`, …), but has no rule
for the response body `token` field. The API tokens create/reset endpoints return the token
value there, so every re-record writes a live token straight to the cassette. Two cassettes
on `main` carry values recorded that way.

Both values are already invalid – a request to the API with each of them comes back 401 –
and the gemspec excludes `spec/` from `spec.files`, so no cassette has ever shipped in a
published gem. This is fixture hygiene, not an incident, and no history rewrite is involved.

## Changes

- add a response body `token` rule to the VCR sensitive data filter, so re-records write
  `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` instead of whatever the API returned
- redact the two token values already committed in the API tokens create/reset cassettes

`last_4_digits` is left as is – it is not a credential, and the list/get cassettes carry it
already.

## How to test

- [ ] `bundle exec rspec spec/mailtrap/api_tokens_api_spec.rb` – 10 examples, 0 failures.
      The examples match on `token: an_instance_of(String)`, so the placeholder satisfies them.
- [ ] `bundle exec rspec` – full suite green, no other cassette depends on a token value.
- [ ] `grep -rE '"token":"[0-9a-f]{32}"' spec/` – returns nothing.
- [ ] `bundle exec rubocop` – no offenses.
- [ ] With API credentials: delete `spec/fixtures/vcr_cassettes/Mailtrap_ApiTokensAPI/_create/maps_response_data_to_ApiToken_with_full_token_value.yml`,
      re-record it with `bin/record-vcr`, and check the written file – the `token` field
      should come back as the placeholder, and the created token should still be revoked
      afterwards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Sensitive API token values are now masked in recorded test data.
  - Added automatic redaction for token values in captured responses.
- **Tests**
  - Updated API token test fixtures to use safe placeholder values instead of real token data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->